### PR TITLE
Document config variables in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-# edge-node-manager [![Go Report Card](https://goreportcard.com/badge/github.com/resin-io/edge-node-manager)](https://goreportcard.com/report/github.com/resin-io/edge-node-manager) [![Build Status](https://travis-ci.com/resin-io/edge-node-manager.svg?token=SsmNYChpKvn5yEXMkM2D&branch=master)](https://travis-ci.com/resin-io/edge-node-manager)
+# edge-node-manager
+[![Go Report Card](https://goreportcard.com/badge/github.com/resin-io/edge-node-manager)](https://goreportcard.com/report/github.com/resin-io/edge-node-manager)
+[![Build Status](https://travis-ci.com/resin-io/edge-node-manager.svg?token=SsmNYChpKvn5yEXMkM2D&branch=master)](https://travis-ci.com/resin-io/edge-node-manager)
+
 resin.io dependent device edge-node-manager written in Go.
 
 ## Getting started
  - Sign up on [resin.io](https://dashboard.resin.io/signup)
- - Work through the [getting started guide](https://docs.resin.io/raspberrypi3/nodejs/getting-started/)
+ - Work through the [getting started
+   guide](https://docs.resin.io/raspberrypi3/nodejs/getting-started/)
  - Create a new application
  - Set these variables in the `Fleet Configuration` application side tab
     - `RESIN_SUPERVISOR_DELTA=1`
@@ -12,25 +16,53 @@ resin.io dependent device edge-node-manager written in Go.
  - Add the dependent application `resin remote` to your local workspace
  - Provision a gateway device
  - Push code to resin as normal :)
- - Follow the readme of the [supported dependent device](#supported-dependent-devices) you would like to use
+ - Follow the readme of the [supported dependent
+   device](#supported-dependent-devices) you would like to use
 
-## Supported dependent devices
- - [micro:bit](https://github.com/resin-io-projects/micro-bit)
- - [nRF51822-DK](https://github.com/resin-io-projects/nRF51822-DK)
- - [ESP8266](https://github.com/resin-io-projects/esp8266)
+## Configuration variables
+More info about environment variables can be found in
+the [documentation](https://docs.resin.io/management/env-vars/). If you
+don't set environment variables the default will be used.
+
+Environment Variable | Default | Description
+------------ | ------------- | -------------
+ENM_LOG_LEVEL | `info` | the edge-node-manager log level
+DEPENDENT_LOG_LEVEL | `info` | the dependent device log level
+ENM_CONFIG_LOOP_DELAY | `10` | the time delay in seconds between each application process loop
+ENM_CONFIG_PAUSE_DELAY | `10` | the time delay in seconds between each pause check
+ENM_HOTSPOT_SSID | `resin-hotspot` | the SSID used for the hotspot
+ENM_HOTSPOT_PASSWORD | `resin-hotspot` | the password used for the hotspot
+ENM_BLUETOOTH_SHORT_TIMEOUT | `1` | the timeout in seconds for instantaneous bluetooth operations
+ENM_BLUETOOTH_LONG_TIMEOUT | `10` | the timeout in seconds for long running bluetooth operations
+ENM_NMAP_TIMEOUT | `30` | the timeout in seconds for nmap scan operations
+ENM_UPDATE_RETRIES | `1` | the number of times the firmware update process should be retried
+ENM_ASSETS_DIRECTORY | `/data/assets` | the root directory used to store the dependent device firmware
+ENM_DB_DIRECTORY | `/data/database` | the root directory used to store the database
+ENM_DB_FILE | `enm.db` | the database file name
+ENM_API_VERSION | `v1` | the proxyvisor API version
+RESIN_SUPERVISOR_ADDRESS | `http://127.0.0.1:4000` | the address used to communicate with the proxyvisor
+RESIN_SUPERVISOR_API_KEY | `na` | the api key used to communicate with the proxyvisor
+ENM_LOCK_FILE_LOCATION | `/tmp/resin/resin-updates.lock` | the [lock file](https://github.com/resin-io/resin-supervisor/blob/master/docs/update-locking.md) location
 
 ## API
-The edge-node-manager provides an API that allows the user to set the target status of the main process. This is useful to free up the on-board radios allowing user code to interact directly with the dependent devices e.g. to collect sensor data
+The edge-node-manager provides an API that allows the user to set the
+target status of the main process. This is useful to free up the on-board radios
+allowing user code to interact directly with the dependent devices e.g. to
+collect sensor data.
 
-**Warning** - Do not try and interact with the on-board radios whilst the edge-node-manager is running (this leads to inconsistent, unexpected behaviour).
+**Warning** - Do not try and interact with the on-board radios whilst the
+edge-node-manager is running (this leads to inconsistent, unexpected behaviour).
 
 ### SET /v1/enm/status
 Set the edge-node-manager process status.
 
 #### Example
 ```
-curl -i -H "Content-Type: application/json" -X PUT --data '{"targetStatus":"Paused"}' localhost:1337/v1/enm/status
-curl -i -H "Content-Type: application/json" -X PUT --data '{"targetStatus":"Running"}' localhost:1337/v1/enm/status
+curl -i -H "Content-Type: application/json" -X PUT --data \
+'{"targetStatus":"Paused"}' localhost:1337/v1/enm/status
+
+curl -i -H "Content-Type: application/json" -X PUT --data \
+'{"targetStatus":"Running"}' localhost:1337/v1/enm/status
 ```
 
 #### Response
@@ -55,11 +87,18 @@ HTTP/1.1 200 OK
 }
 ```
 
+## Supported dependent devices
+- [micro:bit](https://github.com/resin-io-projects/micro-bit)
+- [nRF51822-DK](https://github.com/resin-io-projects/nRF51822-DK)
+- [ESP8266](https://github.com/resin-io-projects/esp8266)
+
 ## Further reading
 ### About
-The edge-node-manager is an example of a gateway application designed to bridge the gap between Resin OS capable single board
-computers (e.g. the Raspberry Pi) and non Resin OS capable devices (e.g. micro-controllers). It has been designed to make it as
-easy as possible to add new supported dependent device types and to run alongside your user application.
+The edge-node-manager is an example of a gateway
+application designed to bridge the gap between Resin OS capable single board
+computers (e.g. the Raspberry Pi) and non Resin OS capable devices (e.g.
+micro-controllers). It has been designed to make it as easy as possible to add
+new supported dependent device types and to run alongside your user application.
 
 The following functionality is implemented:
  - Dependent device detection
@@ -71,11 +110,14 @@ The following functionality is implemented:
 
 ### Definitions
 #### Dependent application
-A dependent application is a Resin application that targets devices not capable of interacting directly with the Resin API.
+A dependent application is a Resin application that targets devices not capable
+of interacting directly with the Resin API.
 
-The dependent application is scoped under a Resin application, which gets the definition of gateway application.
+The dependent application is scoped under a Resin application, which gets the
+definition of gateway application.
 
-A dependent application follows the same development cycle as a conventional Resin application:
+A dependent application follows the same development cycle as a conventional
+Resin application:
  - It binds to your git workspace via the `resin remote`
  - It consists of a Docker application
  - It offers the same environment and configuration variables management
@@ -83,21 +125,26 @@ A dependent application follows the same development cycle as a conventional Res
 There are some key differences:
  - It does not support Dockerfile templating
  - The Dockerfile must target an x86 base image
- - The actual firmware must be stored in the `/assets` folder within the built docker image
+ - The actual firmware must be stored in the `/assets` folder within the built
+   docker image
 
 #### Dependent device
-A dependent device is a device not capable of interacting directly with the Resin API - the reasons can be several, the most common are:
+A dependent device is a device not capable of interacting directly with the
+Resin API - the reasons can be several, the most common are:
  - No direct Internet capabilities
  - Not able to run the Resin OS (being a microcontroller, for example)
 
 #### Gateway application
-The gateway application is responsible for detecting, provisioning and managing dependent devices belonging to one of its dependent
-applications. This is possible leveraging a new set of endpoints exposed by the [Resin Supervisor](https://github.com/resin-io/resin-supervisor).
+The gateway application is responsible for detecting, provisioning and managing
+dependent devices belonging to one of its dependent applications. This is
+possible leveraging a new set of endpoints exposed by the [Resin
+Supervisor](https://github.com/resin-io/resin-supervisor).
 
 The edge-node-manager (this repository) is an example of a gateway application.
 
 #### Gateway device
-The gateway device runs the gateway application and has the needed on-board radios to communicate with the managed dependent devices, for example:
+The gateway device runs the gateway application and has the needed on-board
+radios to communicate with the managed dependent devices, for example:
  - Bluetooth
  - WiFi
  - LoRa


### PR DESCRIPTION
Change-type: patch

Vim changed all the lines to be a maximum of 80 characters long, the only new content is the `Configuration Variables` section