### PR TITLE
Handle config

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -11,13 +11,11 @@ import (
 )
 
 type Application struct {
-	Board        board.Interface        `json:"-"`
-	BoardType    board.Type             `json:"-"`
-	Name         string                 `json:"name"`
-	ResinUUID    int                    `json:"id"`
-	Commit       string                 `json:"-"`      // Ignore this when unmarshalling from the supervisor as we want to set the target commit
-	TargetCommit string                 `json:"commit"` // Set json tag to commit as the supervisor has no concept of target commit
-	Config       map[string]interface{} `json:"config"`
+	Board     board.Interface        `json:"-"`
+	BoardType board.Type             `json:"-"`
+	Name      string                 `json:"name"`
+	ResinUUID int                    `json:"id"`
+	Config    map[string]interface{} `json:"config"`
 }
 
 func (a Application) String() string {
@@ -25,14 +23,10 @@ func (a Application) String() string {
 		"Board type: %s, "+
 			"Name: %s, "+
 			"Resin UUID: %d, "+
-			"Commit: %s, "+
-			"Target commit: %s, "+
 			"Config: %v",
 		a.BoardType,
 		a.Name,
 		a.ResinUUID,
-		a.Commit,
-		a.TargetCommit,
 		a.Config)
 }
 

--- a/device/device.go
+++ b/device/device.go
@@ -66,14 +66,18 @@ func (d Device) String() string {
 
 func New(applicationUUID int, boardType board.Type, name, localUUID, resinUUID string) Device {
 	return Device{
-		ApplicationUUID: applicationUUID,
-		BoardType:       boardType,
-		Name:            name,
-		LocalUUID:       localUUID,
-		ResinUUID:       resinUUID,
-		Commit:          "",
-		TargetCommit:    "",
-		Status:          status.OFFLINE,
+		ApplicationUUID:   applicationUUID,
+		BoardType:         boardType,
+		Name:              name,
+		LocalUUID:         localUUID,
+		ResinUUID:         resinUUID,
+		Commit:            "",
+		TargetCommit:      "",
+		Status:            status.OFFLINE,
+		Config:            make(map[string]interface{}),
+		TargetConfig:      make(map[string]interface{}),
+		Environment:       make(map[string]interface{}),
+		TargetEnvironment: make(map[string]interface{}),
 	}
 }
 
@@ -115,8 +119,6 @@ func (d *Device) PopulateBoard() error {
 
 // Sync device with resin to ensure we have the latest values for:
 // - Device name
-// - Device target config
-// - Device target environment
 func (d *Device) Sync() []error {
 	bytes, errs := supervisor.DependentDeviceInfo(d.ResinUUID)
 	if errs != nil {
@@ -131,8 +133,6 @@ func (d *Device) Sync() []error {
 	}
 
 	d.Name = temp.Name
-	d.TargetConfig = temp.TargetConfig
-	d.TargetEnvironment = temp.TargetEnvironment
 
 	return nil
 }

--- a/process/process.go
+++ b/process/process.go
@@ -291,7 +291,7 @@ func sendState(d device.Device) []error {
 		online = false
 	}
 
-	return supervisor.DependentDeviceInfoUpdateWithOnlineState(d.ResinUUID, (string)(d.Status), d.Commit, online)
+	return supervisor.DependentDeviceInfoUpdateWithOnlineState(d.ResinUUID, (string)(d.Status), d.Commit, d.TargetEnvironment, d.TargetConfig, online)
 }
 
 func updateFirmware(d device.Device) []error {

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -153,22 +153,26 @@ func DependentDeviceLog(UUID, message string) []error {
 	return handleResp(resp, errs, 202)
 }
 
-func DependentDeviceInfoUpdateWithOnlineState(UUID, status, commit string, online bool) []error {
+func DependentDeviceInfoUpdateWithOnlineState(UUID, status, commit string, environment, config map[string]interface{}, online bool) []error {
 	url, err := buildPath(address, []string{version, "devices", UUID})
 	if err != nil {
 		return []error{err}
 	}
 
 	type dependentDeviceInfo struct {
-		Status string `json:"status"`
-		Online bool   `json:"is_online"`
-		Commit string `json:"commit,omitempty"`
+		Status      string                 `json:"status"`
+		Commit      string                 `json:"commit,omitempty"`
+		Environment map[string]interface{} `json:"environment"`
+		Config      map[string]interface{} `json:"config"`
+		Online      bool                   `json:"is_online,omitempty"`
 	}
 
 	content := &dependentDeviceInfo{
-		Status: status,
-		Online: online,
-		Commit: commit,
+		Status:      status,
+		Commit:      commit,
+		Environment: environment,
+		Config:      config,
+		Online:      online,
 	}
 
 	bytes, err := json.Marshal(content)
@@ -193,20 +197,25 @@ func DependentDeviceInfoUpdateWithOnlineState(UUID, status, commit string, onlin
 	return handleResp(resp, errs, 200)
 }
 
-func DependentDeviceInfoUpdateWithoutOnlineState(UUID, status, commit string) []error {
+func DependentDeviceInfoUpdateWithoutOnlineState(UUID, status, commit string, environment, config map[string]interface{}) []error {
 	url, err := buildPath(address, []string{version, "devices", UUID})
 	if err != nil {
 		return []error{err}
 	}
 
 	type dependentDeviceInfo struct {
-		Status string `json:"status"`
-		Commit string `json:"commit,omitempty"`
+		Status      string                 `json:"status"`
+		Commit      string                 `json:"commit,omitempty"`
+		Environment map[string]interface{} `json:"environment"`
+		Config      map[string]interface{} `json:"config"`
+		Online      bool                   `json:"is_online,omitempty"`
 	}
 
 	content := &dependentDeviceInfo{
-		Status: status,
-		Commit: commit,
+		Status:      status,
+		Commit:      commit,
+		Environment: environment,
+		Config:      config,
 	}
 
 	bytes, err := json.Marshal(content)


### PR DESCRIPTION
Store config and environment supplied by the supervisor and transmit the info back to the supervisor to stop the `update` hook from continually firing.

Whilst doing the above I re-factored the handlers to remove some code duplication